### PR TITLE
expand max disparity limit

### DIFF
--- a/cfg/VXSGBM.cfg
+++ b/cfg/VXSGBM.cfg
@@ -17,7 +17,7 @@ gen.add("bt_clip_value",           int_t, 0, "Truncation value (must be odd) for
 gen.add("ct_win_size",             int_t, 0, "Specifies the census transform window size", 0, 0, 31)
 gen.add("hc_win_size",             int_t, 0, "Specifies the hamming cost window size", 0, 0, 31)
 gen.add("min_disparity",           int_t, 0, "Disparity to begin search at, pixels", 0, 0, 256)
-gen.add("max_disparity",           int_t, 0, "Disparity to finish search at, pixels (Must be divisible by 4)", 64, 0, 256)
+gen.add("max_disparity",           int_t, 0, "Disparity to finish search at, pixels (Must be divisible by 4)", 64, 0, 512)
 
 # scan path flags
 gen.add("SCANLINE_LEFT_RIGHT",            bool_t, 0, "Aggregate cost from left to right horizontally", True)


### PR DESCRIPTION
expand `max_disparity` range for wide baseline stereo camera.